### PR TITLE
Add .gitignore and requirements file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-venv/
 log.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pynput==1.4.4
+python-xlib==0.25
+six==1.12.0


### PR DESCRIPTION
Add `.gitignore` file to avoid adding python virtual environment and log.txt file to source control.
Also, add a requirements file with all the required dependencies.